### PR TITLE
Fix the incorrect base address under paging for cryptoknight test.

### DIFF
--- a/kernel/kern/test.S
+++ b/kernel/kern/test.S
@@ -103,7 +103,11 @@ UTEST_SPIN:
 #endif
 
 UTEST_CRYPTONIGHT:
+#ifdef ENABLE_PAGING
+    li a0, 0x7FC10000
+#else
     li a0, 0x80400000 // base addr
+#endif
     li a1, 0x200000 // 2M bytes
     li a3, 524288 // number of iterations
     li a4, 0x1FFFFC // 2M mask


### PR DESCRIPTION
Change base address for cryptoknight to va[0x7FC10000] = pa[0x80400000] when paging is activated. 